### PR TITLE
add ACOND ASTI-09UW4RVEDC00 to compatible devices

### DIFF
--- a/doc/hardware/COMPATIBLE_DEVICES.md
+++ b/doc/hardware/COMPATIBLE_DEVICES.md
@@ -8,6 +8,7 @@ This document lists the Hisense AC models that have been tested and confirmed to
 |----------|-------------|
 | Tornado TOP-INV-120A | AEH-W4F1 |
 | Hisense AST-12UW4RVETG00A | AEH-W4E1 |
+| ACOND ASTI-09UW4RVEDC00 | AEH-W4B1 |
 
 ## Adding Your Device
 


### PR DESCRIPTION
## Summary

  Adds the ACOND ASTI-09UW4RVEDC00 air conditioner with the AEH-W4B1 WiFi module to the list of confirmed working devices.

  ## Hardware details

  - AC model: ACOND ASTI-09UW4RVEDC00
  - WiFi module: AEH-W4B1
  - Module hardware revision: DL3036A-V1.1
  - Pinout and connection: identical to the previously supported WiFi modules

  The device has been tested and confirmed to work with this ESPHome component.